### PR TITLE
external project dependency 추가해보기

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
+
+set(DEP_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/Dependencies)
+include(Dependencies.cmake)
+
 project(opengl)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -7,13 +11,15 @@ add_executable(opengl Driver.cpp Application.h TessellationApp.cpp TessellationA
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIRS})
+target_include_directories(opengl PUBLIC ${SDL2_INCLUDE_DIRS})
 target_link_libraries(opengl ${SDL2_LIBRARIES})
 
 find_package(OPENGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIR})
+target_include_directories(opengl PUBLIC ${OPENGL_INCLUDE_DIR})
 target_link_libraries(opengl ${OPENGL_LIBRARY})
 
 find_package(GLM REQUIRED)
-include_directories(${GLM_INCLUDE_DIR})
+target_include_directories(opengl PUBLIC ${GLM_INCLUDE_DIR})
 target_link_libraries(opengl ${GLM_LIBRARY})
+
+target_include_directories(opengl PUBLIC ${DEP_INSTALL_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ include(Dependencies.cmake)
 project(opengl)
 
 set(CMAKE_CXX_STANDARD 17)
+
 add_executable(opengl Driver.cpp Application.h TessellationApp.cpp TessellationApp.h OpenGl.cpp OpenGl.h)
+add_executable(opengl_test Test.cpp)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -23,3 +25,10 @@ target_include_directories(opengl PUBLIC ${GLM_INCLUDE_DIR})
 target_link_libraries(opengl ${GLM_LIBRARY})
 
 target_include_directories(opengl PUBLIC ${DEP_INSTALL_DIR}/include)
+target_include_directories(opengl_test PUBLIC ${DEP_INSTALL_DIR}/include)
+
+add_dependencies(opengl dep_spdlog dep_catch)
+add_dependencies(opengl_test opengl)
+
+enable_testing()
+add_test(NAME opengl COMMAND opengl_test)

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -1,0 +1,29 @@
+include(ExternalProject)
+
+# for logging
+ExternalProject_Add(
+    dep_spdlog
+    GIT_REPOSITORY "https://github.com/gabime/spdlog"
+    GIT_TAG "v0.17.0"
+    GIT_SHALLOW 1
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+    CMAKE_ARGS
+        -DSPDLOG_BUILD_EXAMPLES=OFF
+        -DSPDLOG_BUILD_TESTING=OFF
+        -DCMAKE_INSTALL_PREFIX=${DEP_INSTALL_DIR}
+    TEST_COMMAND ""
+)
+
+# for testing
+ExternalProject_Add(
+    dep_catch
+    GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+    GIT_TAG "v2.3.0"
+    GIT_SHALLOW 1
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${DEP_INSTALL_DIR}
+        -DCATCH_BUILD_TESTING=OFF -DCATCH_INSTALL_DOCS=OFF -DCATCH_INSTALL_HELPERS=OFF
+    TEST_COMMAND ""
+)

--- a/Test.cpp
+++ b/Test.cpp
@@ -1,0 +1,5 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+TEST_CASE("It should work", "[Test]") {
+}

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,0 +1,5 @@
+cmake -H. -Bcmake-build-debug
+cd cmake-build-debug
+cmake --build . --config Debug
+ctest
+cd ..


### PR DESCRIPTION
closes #4 

- `Dependencies.cmake`라는 파일을 만들어다가 여기에 `ExternalProject_Add`를 쓰는 cmake 스크립트를 모아둠니다
- 그간의 크로스 플랫폼용 external project 세팅을 경험해본 결과, 어짜피 abi가 달라지면 빌드를 다시하게 되니 install 패스를 소스 디렉토리쪽에 노출시키는게 별 의미가 없더군여. 그래서 이번에는 빌드 디렉토리 안에 인스톨되게 해봤습니다. 어짜피 include path나 library path를 위한 dependency install path를 변수로 뽑으니 설정에 불편은 없을듯요
- 슬슬 test 빌드를 위한 코드와 library 빌드를 위한 코드, binary 빌드를 위한 코드를 분리하는 편이 나을듯 하군요 ㅎㅎ